### PR TITLE
Fix templates path, so that it reverts to original templates path after the plugin is run.

### DIFF
--- a/variables/FormBuilder2Variable.php
+++ b/variables/FormBuilder2Variable.php
@@ -123,6 +123,7 @@ class FormBuilder2Variable
 	  $attributes 			= $theField->attributes;
 	  $pluginSettings 	= craft()->plugins->getPlugin('FormBuilder2')->getSettings(); // DEPRICATE
 
+    $originalTemplatesPath = craft()->path->getTemplatesPath();
 	  craft()->path->setTemplatesPath(craft()->path->getPluginsPath());
 
 	  $templatePath = craft()->path->getPluginsPath() . 'plugins/formbuilder2/templates/inputs/';
@@ -258,6 +259,7 @@ class FormBuilder2Variable
 	    break;
 	  }
 
+    craft()->path->setTemplatesPath($originalTemplatesPath);
 	  return $html;
 	}
 


### PR DESCRIPTION
After running the plugin in a template, I could not include other templates. For example, if I put the form code in my template, then at the end of the template, I have {% include 'footer.html' %} it gives an error that the template cannot be found. After some poking around, I see that the formbuilder code changes the template path, without changing it back to the original template path. This commit fixes that.