### PR TITLE
Fix closing paragraph tag on error message

### DIFF
--- a/sampleForm.twig
+++ b/sampleForm.twig
@@ -29,7 +29,7 @@
 
   {# Errors/Success Messages #}
   <div class="notifications">
-    <p class="notification error-message">{{ craft.session.getFlash('error') | raw }}<p>
+    <p class="notification error-message">{{ craft.session.getFlash('error') | raw }}</p>
     <p class="notification success-message">{{ craft.session.getFlash('success') | raw }}</p>
     {% set errors = (errors is defined ? errors : null) %}
     {% if errors %}


### PR DESCRIPTION
The error message paragraph element has an incorrect closing tag.