### PR TITLE
Fix asset validation

### DIFF
--- a/formbuilder2/FormBuilder2Plugin.php
+++ b/formbuilder2/FormBuilder2Plugin.php
@@ -6,7 +6,7 @@ Plugin Url: https://github.com/roundhouse/FormBuilder-2
 Author: Vadim Goncharov (https://github.com/owldesign)
 Author URI: http://roundhouseagency.com
 Description: FormBuilder 2 is a Craft CMS plugin that lets you create forms for your front-end.
-Version: 2.0.18
+Version: 2.0.19
 */
 
 namespace Craft;
@@ -97,7 +97,7 @@ class FormBuilder2Plugin extends BasePlugin
 
 	public function getVersion()
 	{
-		return '2.0.18';
+		return '2.0.19';
 	}
 
 	public function getDeveloper()

--- a/formbuilder2/services/FormBuilder2_EntryService.php
+++ b/formbuilder2/services/FormBuilder2_EntryService.php
@@ -133,14 +133,14 @@ class FormBuilder2_EntryService extends BaseApplicationComponent
       switch ($field->type) {
         case "Assets":
           if ($field->required) {
-            $text = craft()->request->getPost($field->handle);
-            $textArray = array_filter($text);
-            if (empty($textArray)) {
+            $assets = UploadedFile::getInstancesByName($field->handle);
+            if (empty($assets)) {
               $errorMessage[$field->handle] = Craft::t('{fieldname} cannot be empty.', array(
                                                 'fieldname' => $field->name
                                               ));
             }
           }
+        break;
         case "PlainText":
           if ($field->required) {
             $text = craft()->request->getPost($field->handle);


### PR DESCRIPTION
Had a similar issue to #134. Had asset fields in my form that I added validation to. Attempting to submit a form with these empty or not was returning the same error message as described in that issue. 

Upon inspecting the $field value that is local to the function, I noticed it wasn't including the files uploading from the field. I'm guessing this has something to do with the POST being multipart to handle the file uploads. After switching to use the UploadedFile::getInstancesByName method to pull the files based on the field handle, I noticed I was still getting errors. After some debugging, I found it was just falling through to the next case statement so I added the missing break. Gotta love the little errors!

I also appended the version number. Not sure if this was best practice or not as I didn't see any contribution documentation. Hope this helps! Let me know if you'd like any further explanation or would like me to change anything!