### PR TITLE
Fix instructions output

### DIFF
--- a/formbuilder2/FormBuilder2Plugin.php
+++ b/formbuilder2/FormBuilder2Plugin.php
@@ -6,7 +6,7 @@ Plugin Url: https://github.com/roundhouse/FormBuilder-2
 Author: Vadim Goncharov (https://github.com/owldesign)
 Author URI: http://roundhouseagency.com
 Description: FormBuilder 2 is a Craft CMS plugin that lets you create forms for your front-end.
-Version: 2.1.0
+Version: 2.1.1
 */
 
 namespace Craft;
@@ -97,7 +97,7 @@ class FormBuilder2Plugin extends BasePlugin
 
 	public function getVersion()
 	{
-		return '2.1.0';
+		return '2.1.1';
 	}
 
 	public function getDeveloper()

--- a/formbuilder2/templates/inputs/checkbox.twig
+++ b/formbuilder2/templates/inputs/checkbox.twig
@@ -12,7 +12,7 @@
 			</label>
 		{% endif %}
 		{% if instructions %}
-			<div class="instructions">{{ instructions|md|t }}</div>
+			<div class="instructions">{{ instructions|md|t|raw }}</div>
 		{% endif %}
 	</div>
 	{% endif %}

--- a/formbuilder2/templates/inputs/color.twig
+++ b/formbuilder2/templates/inputs/color.twig
@@ -10,7 +10,7 @@
         </label>
       {% endif %}
       {% if instructions %}
-        <div class="instructions">{{ instructions|md|t }}</div>
+        <div class="instructions">{{ instructions|md|t|raw }}</div>
       {% endif %}
     </div>
   {% endif %}

--- a/formbuilder2/templates/inputs/datetime.twig
+++ b/formbuilder2/templates/inputs/datetime.twig
@@ -16,7 +16,7 @@
       </label>
     {% endif %}
     {% if instructions %}
-      <div class="instructions">{{ instructions|md|t }}</div>
+      <div class="instructions">{{ instructions|md|t|raw }}</div>
     {% endif %}
   </div>
 {% endif %}

--- a/formbuilder2/templates/inputs/email.twig
+++ b/formbuilder2/templates/inputs/email.twig
@@ -12,7 +12,7 @@
         </label>
       {% endif %}
       {% if instructions %}
-        <div class="instructions">{{ instructions|md|t }}</div>
+        <div class="instructions">{{ instructions|md|t|raw }}</div>
       {% endif %}
     </div>
   {% endif %}

--- a/formbuilder2/templates/inputs/entries.twig
+++ b/formbuilder2/templates/inputs/entries.twig
@@ -12,7 +12,7 @@
         </label>
       {% endif %}
       {% if instructions %}
-        <div class="instructions">{{ instructions|md|t }}</div>
+        <div class="instructions">{{ instructions|md|t|raw }}</div>
       {% endif %}
     </div>
   {% endif %}

--- a/formbuilder2/templates/inputs/file.twig
+++ b/formbuilder2/templates/inputs/file.twig
@@ -9,7 +9,7 @@
         </label>
       {% endif %}
       {% if instructions %}
-        <div class="instructions">{{ instructions|md|t }}</div>
+        <div class="instructions">{{ instructions|md|t|raw }}</div>
       {% endif %}
     </div>
   {% endif %}

--- a/formbuilder2/templates/inputs/lightswitch.twig
+++ b/formbuilder2/templates/inputs/lightswitch.twig
@@ -9,7 +9,7 @@
 	      </label>
 	    {% endif %}
 	    {% if instructions %}
-	      <div class="instructions">{{ instructions|md|t }}</div>
+	      <div class="instructions">{{ instructions|md|t|raw }}</div>
 	    {% endif %}
 	  </div>
 	{% endif %}

--- a/formbuilder2/templates/inputs/link.twig
+++ b/formbuilder2/templates/inputs/link.twig
@@ -12,7 +12,7 @@
         </label>
       {% endif %}
       {% if instructions %}
-        <div class="instructions">{{ instructions|md|t }}</div>
+        <div class="instructions">{{ instructions|md|t|raw }}</div>
       {% endif %}
     </div>
   {% endif %}

--- a/formbuilder2/templates/inputs/multiselect.twig
+++ b/formbuilder2/templates/inputs/multiselect.twig
@@ -11,7 +11,7 @@
 			</label>
 		{% endif %}
 		{% if instructions %}
-			<div class="instructions">{{ instructions|md|t }}</div>
+			<div class="instructions">{{ instructions|md|t|raw }}</div>
 		{% endif %}
 	</div>
 	{% endif %}

--- a/formbuilder2/templates/inputs/number.twig
+++ b/formbuilder2/templates/inputs/number.twig
@@ -11,7 +11,7 @@
         </label>
       {% endif %}
       {% if instructions %}
-        <div class="instructions">{{ instructions|md|t }}</div>
+        <div class="instructions">{{ instructions|md|t|raw }}</div>
       {% endif %}
     </div>
   {% endif %}

--- a/formbuilder2/templates/inputs/phone.twig
+++ b/formbuilder2/templates/inputs/phone.twig
@@ -12,7 +12,7 @@
         </label>
       {% endif %}
       {% if instructions %}
-        <div class="instructions">{{ instructions|md|t }}</div>
+        <div class="instructions">{{ instructions|md|t|raw }}</div>
       {% endif %}
     </div>
   {% endif %}

--- a/formbuilder2/templates/inputs/radio.twig
+++ b/formbuilder2/templates/inputs/radio.twig
@@ -8,7 +8,7 @@
 			</label>
 		{% endif %}
 		{% if instructions %}
-			<div class="instructions">{{ instructions|md|t }}</div>
+			<div class="instructions">{{ instructions|md|t|raw }}</div>
 		{% endif %}
 	</div>
 	{% endif %}

--- a/formbuilder2/templates/inputs/richtext.twig
+++ b/formbuilder2/templates/inputs/richtext.twig
@@ -10,7 +10,7 @@
 				</label>
 			{% endif %}
 			{% if instructions %}
-				<div class="instructions">{{ instructions|md|t }}</div>
+				<div class="instructions">{{ instructions|md|t|raw }}</div>
 			{% endif %}
 		</div>
 	{% endif %}

--- a/formbuilder2/templates/inputs/select.twig
+++ b/formbuilder2/templates/inputs/select.twig
@@ -11,7 +11,7 @@
         </label>
       {% endif %}
       {% if instructions %}
-        <div class="instructions">{{ instructions|md|t }}</div>
+        <div class="instructions">{{ instructions|md|t|raw }}</div>
       {% endif %}
     </div>
   {% endif %}

--- a/formbuilder2/templates/inputs/text.twig
+++ b/formbuilder2/templates/inputs/text.twig
@@ -12,7 +12,7 @@
         </label>
       {% endif %}
       {% if instructions %}
-        <div class="instructions">{{ instructions|md|t }}</div>
+        <div class="instructions">{{ instructions|md|t|raw }}</div>
       {% endif %}
     </div>
   {% endif %}

--- a/formbuilder2/templates/inputs/textarea.twig
+++ b/formbuilder2/templates/inputs/textarea.twig
@@ -10,7 +10,7 @@
 				</label>
 			{% endif %}
 			{% if instructions %}
-				<div class="instructions">{{ instructions|md|t }}</div>
+				<div class="instructions">{{ instructions|md|t|raw }}</div>
 			{% endif %}
 		</div>
 	{% endif %}


### PR DESCRIPTION
Pull request to resolve issue [148](https://github.com/roundhouse/FormBuilder-2-Craft-CMS/issues/148) by adding `|raw` filter to instructions output.